### PR TITLE
온보딩 이미지 중앙 정렬 안되던 현상 개선

### DIFF
--- a/app/src/main/java/team/nexters/semonemo/ui/start/onboarding/OnBoardingScreen.kt
+++ b/app/src/main/java/team/nexters/semonemo/ui/start/onboarding/OnBoardingScreen.kt
@@ -102,6 +102,7 @@ internal fun OnBoardingContent(
     onStartButtonClicked: () -> Unit
 ) {
     Column(
+        modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Image(


### PR DESCRIPTION
`Alignment.CenterHorizontally`가 적용되어 있었지만 Layout이 전체 영역을 차지하고 있지 않아서
영역을 전체로 늘리는 코드를 추가했습니다.